### PR TITLE
fix: file-loader public path now matches Django's static frontend folder

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -33,7 +33,10 @@ module.exports = {
       {
         test: /\.(png|jpe?g|gif)$/i,
         use: {
-          loader: 'file-loader'
+          loader: 'file-loader',
+          options: {
+            publicPath: '/static/frontend/'
+          }
         }
       }
     ]


### PR DESCRIPTION
Fixes #87 