### PR TITLE
feat: management command for setting entry folder

### DIFF
--- a/backend/management/commands/setentryfolder.py
+++ b/backend/management/commands/setentryfolder.py
@@ -1,0 +1,14 @@
+from django.core.management.base import BaseCommand
+from backend.file_manager import build_file_structure
+
+
+class Command(BaseCommand):
+    help = 'Sets entry folder to given file path.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('folder', type=str, help='Path to entry folder')
+
+    def handle(self, *args, **kwargs):
+        folder = kwargs['folder']
+        build_file_structure(file_path=folder)
+        self.stdout.write("Added {} as entry folder.".format(folder))


### PR DESCRIPTION
Created a management command for setting the entry folder.
The command can be invoked with:
`python manage.py setentryfolder <absolute path>`

Closes #154 