### PR TITLE
fix: mock assets in jest-test files

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,10 @@
     "test": "jest"
   },
   "jest": {
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
+    },
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     }


### PR DESCRIPTION
In tests; now ignores most common files such ass css-files and others, for example jpg, png

Closes #160 