### PR TITLE
Fix/error create project same name

### DIFF
--- a/backend/database_wrapper.py
+++ b/backend/database_wrapper.py
@@ -28,10 +28,10 @@ def create_project(name: str) -> int:
     :return: The created project's id (primary key).
     """
 
-    if not Project.objects.filter(name=name):
-        p = Project.objects.create(name=name)
-    else:
-        return None
+    if Project.objects.filter(name=name):
+        raise ValueError
+    p = Project.objects.create(name=name)
+
     return p.id
 
 

--- a/backend/project_manager.py
+++ b/backend/project_manager.py
@@ -30,7 +30,11 @@ def new_project(data: dict) -> (int, dict):
     except KeyError:
         return 400, {}  # Bad request
 
-    pid = create_project(name=name)
+    try:
+        pid = create_project(name=name)
+    except ValueError:
+        return 204, {} #No project found
+
     create_filter(pid=pid)
     return 200, os_aware({PROJECT_ID: pid})
 

--- a/backend/test/test_integration/test_file_manager.py
+++ b/backend/test/test_integration/test_file_manager.py
@@ -92,7 +92,6 @@ class AddFoldersTest(TestCase):
         """
         Test with a folder id that doesn't exist.
         """
-        pid = create_project(name='test_project')
         code, res = add_folder(data={PROJECT_ID: self.pid, FOLDER_ID: 42})
         self.assertEqual(code, 204)
         self.assertEqual(res, {})

--- a/backend/test/test_unit/test_database_wrapper.py
+++ b/backend/test/test_unit/test_database_wrapper.py
@@ -111,7 +111,7 @@ class CreateProjectTest(BaseTestCases.ProjectTest):
         """
         Test that no project can be created with the same name
         """
-        self.assertIsNone(create_project(name="test project"))
+        self.assertRaises(ValueError, lambda: create_project("test project"))
 
 
 class GetProjectByIdTest(BaseTestCases.ProjectTest):


### PR DESCRIPTION
Please look at test_file_manager, a row was deleted that i think is irrelevant, but I am unsure of the purpose of it.

Closes #230 