### PR TITLE
feat: implement clip compression

### DIFF
--- a/backend/exporter.py
+++ b/backend/exporter.py
@@ -1,6 +1,6 @@
 from .database_wrapper import *
 from .communication_utils import *
-
+import gzip
 
 # This file represents the backend Exporter.
 
@@ -28,5 +28,33 @@ def export_filter(data: dict) -> (int, dict):
 
 
 def export_clips(data: dict) -> (int, dict):
-    # TODO: Implement
-    return 200, {}
+    try:
+        cids = data[CLIP_IDS]
+    except KeyError:
+        return 400, {}  # Bad request
+
+    c = compress_clips(clip_ids=cids)
+    if c is None:
+        return 204, {}  # No content
+
+    return 200, c
+
+
+def compress_clips(clip_ids: list) -> (int, list):
+    """
+    :param clip_ids: A list of clip ids to be compressed
+    :return: A list of compressed clips
+    """
+    compressed_clips_list = []
+    for cid in clip_ids:
+        clip = get_clip_by_id(cid)
+        if not clip:
+            raise ValueError("Given clip id is not valid")
+        file = clip.folder.path + clip.folder.name + "/" + clip.name + "." + clip.video_format
+        try:
+            with open(file=file, mode='rb') as f:
+                compressed_clips_list.append(gzip.compress(f.read()))
+        except:
+            pass
+
+    return 200, compressed_clips_list

--- a/backend/test/test_unit/test_exporter.py
+++ b/backend/test/test_unit/test_exporter.py
@@ -1,10 +1,12 @@
 import pytz
 from django.conf import settings
 from django.test import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, Mock, mock_open
 
 # Import module
 from backend.exporter import *
+
+BINARY_TEXT = b'thisisavideofile'
 
 
 class ExportFilterTest(TestCase):
@@ -39,8 +41,36 @@ class ExportFilterTest(TestCase):
 
 class ExportClipsTest(TestCase):
 
-    def test_basic(self):
+    @patch('builtins.open', new_callable=mock_open, read_data=BINARY_TEXT)
+    @patch('backend.exporter.get_clip_by_id')
+    @patch('backend.exporter.gzip.compress')
+    def test_compress_clips(self, mock_compress, mock_get_clip_by_id, mock_file):
+        """
+        Tests the compress_clips function
+        """
+        x = Mock()
+        mock_get_clip_by_id.return_value = x
+        x.folder.path = "home/user/"
+        x.folder.name = "test_folder"
+        x.name = "test_clip"
+        x.video_format = "avi"
+
+        mock_compress.return_value = True
+        code, compressed_list = compress_clips([1, 2, 3])
+        mock_file.assert_called_with(file='home/user/test_folder/test_clip.avi', mode='rb')
+        mock_get_clip_by_id.assert_called()
+        mock_compress.assert_called_with(BINARY_TEXT)
+
+        self.assertEqual(code, 200)
+        self.assertEqual(compressed_list, [True, True, True])
+
+    @patch('backend.exporter.compress_clips')
+    def test_basic(self, mock_compress_clips):
         """
         Makes a simple call.
         """
-        pass
+        mock_compress_clips.return_value = [3, 4]
+        code, compressed = export_clips(data={CLIP_IDS: [1, 2]})
+        mock_compress_clips.assert_called_once_with(clip_ids=[1, 2])
+        self.assertEqual(code, 200)
+        self.assertEqual(compressed, [3, 4])


### PR DESCRIPTION
Implements compress_clips and export_clips, as well as tests.
Does not implement sending the files to frontend by dividing up into smaller pieces.

Closes #115 