### PR TITLE
fix: update get_filter

### DIFF
--- a/backend/database_wrapper.py
+++ b/backend/database_wrapper.py
@@ -718,6 +718,21 @@ def get_all_classes_in_filter(fid: int) -> List[ObjectClass]:
     return f.classes.all()[::1]
 
 
+# --- Object class ---
+
+def get_object_class_by_id(ocid: int) -> Optional[ObjectClass]:
+    """
+    Gets an object class by id.
+
+    :param ocid: The object class's id.
+    :return: An object class or None.
+    """
+    try:
+        return ObjectClass.objects.get(id=ocid)
+    except ObjectClass.DoesNotExist:
+        return None
+
+
 # --- Object Detection ---
 
 def create_object_detection(cid: int, sample_rate: float, start_time: timezone.datetime, end_time: timezone.datetime,

--- a/backend/filter_module.py
+++ b/backend/filter_module.py
@@ -215,7 +215,6 @@ def get_filter(data: dict) -> (int, dict):
     except KeyError:
         return 400, {}  # Bad request
 
-
     found_filter = dbw.get_filter_by_id(fid)
     if not found_filter:
         return 204, {}  # No content
@@ -226,4 +225,23 @@ def get_filter(data: dict) -> (int, dict):
     if found_filter.end_time == timezone.datetime.max.replace(tzinfo=utc):
         found_filter.end_time = None
 
-    return 200, os_aware({FILTER: serialize(found_filter)})
+    res = modify_objects_in_classes({FILTER: serialize(found_filter)})
+
+    return 200, os_aware(res)
+
+
+def modify_objects_in_classes(data: dict) -> dict:
+    """
+    Modifies the classes list from containing id:s to object class (str).
+
+    :param data: dict with filter.
+    :return: dict with updated filter classes.
+    """
+    classes = []
+    for ocid in data[FILTER]['classes']:
+        oc = dbw.get_object_class_by_id(ocid=ocid)
+        classes.append(oc.object_class)
+
+    data[FILTER]['classes'] = classes
+
+    return data

--- a/backend/test/test_integration/test_filter_module.py
+++ b/backend/test/test_integration/test_filter_module.py
@@ -405,7 +405,6 @@ class GetFilterParametersTest(TestCase):
 
 
 class GetFilterTest(TestCase):
-
     def setUp(self) -> None:
         self.pid = dbw.create_project(name="test_project")
         self.fid = dbw.create_filter(pid=self.pid)
@@ -424,3 +423,13 @@ class GetFilterTest(TestCase):
         """
         data = {FILTER_ID: 42}
         self.assertEqual(get_filter(data), (204, {}))
+
+    def test_returns_string_in_classes(self):
+        """
+        Tests that classes returns string instead of id.
+        """
+        dbw.modify_filter(fid=self.fid, classes=['person', 'bicycle', 'car'])
+        data = {FILTER_ID: self.fid}
+        code, res = get_filter(data)
+        self.assertEqual(code, 200)
+        self.assertEqual(res[FILTER]['classes'], ['person', 'bicycle', 'car'])

--- a/backend/test/test_unit/test_database_wrapper.py
+++ b/backend/test/test_unit/test_database_wrapper.py
@@ -76,6 +76,13 @@ class BaseTestCases:
             self.st = timezone.now() - timezone.timedelta(hours=1)
             self.et = timezone.now()
 
+    class ObjectClassTest(TestCase):
+        """
+        Create an object class.
+        """
+        def setUp(self) -> None:
+            self.ocid = ObjectClass.objects.get_or_create(object_class='car')[0].id
+
     class ObjectDetectionTest(TestCase):
         @patch('backend.database_wrapper.create_hash_sum')
         def setUp(self, mock_create_hash_sum) -> None:
@@ -1069,6 +1076,22 @@ class ModifyFilterTest(BaseTestCases.FilterTest):
         modify_filter(fid=self.fid)
         new = get_project_by_id(self.pid).last_updated
         self.assertNotEqual(old, new)
+
+
+class GetObjectClassByIdTest(BaseTestCases.ObjectClassTest):
+    def test_existing_ocid(self):
+        """
+        Test getting an object class by id.
+        """
+        oc = get_object_class_by_id(ocid=self.ocid)
+        self.assertEqual(oc.id, self.ocid)
+        self.assertEqual(oc.object_class, 'car')
+
+    def test_nonexistent_ocid(self):
+        """
+        Make sure that get function return None for object classes that doesn't exist.
+        """
+        self.assertIsNone(get_object_class_by_id(ocid=42))
 
 
 class GetObjectsInCameraTest(BaseTestCases.ObjectDetectionTest):

--- a/backend/test/test_unit/test_filter_module.py
+++ b/backend/test/test_unit/test_filter_module.py
@@ -155,14 +155,22 @@ class GetFilterParametersTest(TestCase):
 
 class GetFilterTest(TestCase):
 
+    @patch('backend.filter_module.os_aware')
+    @patch('backend.filter_module.modify_objects_in_classes')
     @patch('backend.filter_module.dbw')
-    def test_simple(self, mock_dbw):
+    def test_simple(self, mock_dbw, mock_modify_objects_in_classes, mock_os_aware):
         """
         Makes a simple call to the function
         """
+        mock_modify_objects_in_classes.return_value = 'RETURNED CLASSES LIST'
+        mock_os_aware.return_value = 'RETURNED FROM OS AWARE'
+
         data = {FILTER_ID: 1}
         code, response = get_filter(data)
+
         mock_dbw.get_filter_by_id.assert_called_once_with(1)
+        mock_modify_objects_in_classes.assert_called_once()
+        mock_os_aware.assert_called_once_with('RETURNED CLASSES LIST')
         self.assertEqual(code, 200)
 
     def test_missing_parameter(self):


### PR DESCRIPTION
FILTER['classes'] now contains strings instead of id:s. Is modified after serialization.

Closes #312 