### PR TITLE
Refactor timeline, dynamically move divs

### DIFF
--- a/frontend/src/components/timeline/glassbox.js
+++ b/frontend/src/components/timeline/glassbox.js
@@ -15,6 +15,16 @@ class Glassbox extends Component {
     super(props);
   }
 
+  componentDidMount() {
+    const { childRef } = this.props;
+    childRef(this);
+  }
+
+  componentWillUnmount() {
+    const { childRef } = this.props;
+    childRef(undefined);
+  }
+
   render() {
     return (
       <div

--- a/frontend/src/components/timeline/timeline.module.css
+++ b/frontend/src/components/timeline/timeline.module.css
@@ -44,7 +44,23 @@
 .slider {
   position: relative;
   height: 100%;
-  background-color: rgb(244, 247, 248);
+  /*border: 1px solid;*/
+  overflow: hidden;
+  background-color: rgb(245, 251, 253);
+}
+
+.timestampBox {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+}
+
+.timestamp {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
 }
 
 .line {
@@ -57,15 +73,29 @@
   z-index: 1;
 }
 
+.dateBoxContainer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+}
+
+.dateBox {
+  position: absolute;
+  top: 0;
+  width: 200px;
+  height: 100%;
+}
+
 .date {
-  position: sticky;
-  padding: 7px;
-  margin: 5px;
+  position: absolute;
+  padding: 6px;
   left: 5px;
   top: 5px;
   width: max-content;
   font-size: 11pt;
   border-radius: 3px;
+  text-align: center;
   background-color: #28a745;
   color: white;
   z-index: 3;
@@ -99,7 +129,6 @@
 }
 
 .cliplines {
-  cursor: pointer;
   opacity: 1;
   position: absolute;
   height: 12px;
@@ -134,7 +163,7 @@
   top: -15px;
   width: 100%;
   left: -40px;
-  z-index: 3;
+  z-index: 4;
   cursor: grab;
   pointer-events: auto;
 }

--- a/frontend/src/tests/test_unit/timeline.test.js
+++ b/frontend/src/tests/test_unit/timeline.test.js
@@ -13,10 +13,6 @@ import { GB_SET_TIME_LIMITS, gbSetTimeLimits } from "../../state/stateTimeline";
 //import constants
 import { MAP_MODE, PLAYER_MODE } from "../../state/stateViewport";
 
-//import functions
-import { getLinePlacements } from "../../components/timeline/timeline";
-import { getDayPlacements } from "../../components/timeline/timeline";
-
 // Mock the error function.
 // This is used to count the number of expected errors.
 console.error = jest.fn();
@@ -133,6 +129,7 @@ describe("Timeline reducer", () => {
     });
 
     // Set startTime on endTime
+    // Should throw console error
     expect(
       reducer(nextState, {
         type: SET_START_TIME,
@@ -145,6 +142,7 @@ describe("Timeline reducer", () => {
     });
 
     // Set startTime after endTime
+    // Should throw console error
     expect(
       reducer(nextState, {
         type: SET_START_TIME,
@@ -155,6 +153,10 @@ describe("Timeline reducer", () => {
       startTime: date4,
       timeSpan: nextState.endTime.getTime() - date4.getTime(),
     });
+  });
+
+  it("expect 2 console errors", () => {
+    expect(console.error).toHaveBeenCalledTimes(2);
   });
 
   it("should handle SET_END_TIME", () => {
@@ -196,6 +198,7 @@ describe("Timeline reducer", () => {
     });
 
     // Set endTime on startTime
+    // Should throw console error
     expect(
       reducer(nextState, {
         type: SET_END_TIME,
@@ -208,6 +211,7 @@ describe("Timeline reducer", () => {
     });
 
     // Set endTime before startTime
+    // Should throw console error
     expect(
       reducer(nextState, {
         type: SET_END_TIME,
@@ -220,28 +224,47 @@ describe("Timeline reducer", () => {
     });
   });
 
+  // 2 from SET_START_TIME
+  it("expect 4 console errors", () => {
+    expect(console.error).toHaveBeenCalledTimes(4);
+  });
+
   it("should handle SET_TMIE_LIMITS", () => {
     // Setup variables
-    var date1 = new Date(2020, 3, 5, 12, 0, 0);
-    var date2 = new Date(2020, 4, 12, 16, 0, 0);
-    var date3 = new Date(2020, 4, 12, 18, 0, 0);
-    var date4 = new Date(2020, 7, 20, 18, 0, 0);
+    var date1 = new Date(2020, 2, 5, 12, 0, 0);
+    var date2 = new Date(2020, 3, 12, 16, 0, 0);
+    var date3 = new Date(2020, 4, 3, 12, 0, 0);
+    var date4 = new Date(2020, 4, 5, 18, 30, 0);
+    var date5 = new Date(2020, 5, 12, 18, 0, 0);
+    var date6 = new Date(2020, 7, 20, 18, 0, 0);
+
     var expectedTimeSpan = date3.getTime() - date2.getTime();
+    var gbExpectedTimeSpan = date4.getTime() - date3.getTime();
     var nextState = {
       ...initialState,
       startTime: date2,
       endTime: date3,
       timeSpan: expectedTimeSpan,
+
+      glassbox: {
+        ...initialState.glassbox,
+        startTime: date3,
+        endTime: date4,
+        timeSpan: gbExpectedTimeSpan,
+      },
     };
 
     // Action constant
     expect(SET_TIME_LIMITS).toEqual("SET_TIME_LIMITS");
 
     // Action creator
-    expect(setTimeLimits(date2, date3)).toEqual({
+    // Should throw console error
+    expect(setTimeLimits(date2, date5, undefined, undefined)).toEqual({
       type: SET_TIME_LIMITS,
       start: date2,
-      end: date3,
+      end: date5,
+      gbStart: undefined,
+      gbEnd: undefined,
     });
 
     // Set startTime before endTime
@@ -251,43 +274,78 @@ describe("Timeline reducer", () => {
         {
           type: SET_TIME_LIMITS,
           start: date1,
-          end: date2,
+          end: date5,
+          gbStart: undefined,
+          gbEnd: undefined,
         }
       )
     ).toEqual({
       ...nextState,
       startTime: date1,
-      endTime: date2,
-      timeSpan: date2.getTime() - date1.getTime(),
+      endTime: date5,
+      timeSpan: date5.getTime() - date1.getTime(),
+
+      glassbox: {
+        ...initialState.glassbox,
+        startTime: date3,
+        endTime: date4,
+        timeSpan: gbExpectedTimeSpan,
+      },
     });
 
     // Set startTime equal to endTime
+    // Should throw 2 console errors
     expect(
       reducer(nextState, {
         type: SET_TIME_LIMITS,
         start: date2,
         end: date2,
+        gbStart: date2,
+        gbEnd: date2,
       })
     ).toEqual({
       ...nextState,
       startTime: date2,
       endTime: date2,
       timeSpan: date2.getTime() - date2.getTime(),
+
+      glassbox: {
+        ...initialState.glassbox,
+        startTime: date2,
+        endTime: date2,
+        timeSpan: 0,
+      },
     });
 
     // Set startTime after endTime
+    // Should throw 2 console errors
     expect(
       reducer(nextState, {
         type: SET_TIME_LIMITS,
         start: date4,
         end: date1,
+        gbStart: date2,
+        gbEnd: date3,
       })
     ).toEqual({
       ...nextState,
       startTime: date4,
       endTime: date1,
       timeSpan: date1.getTime() - date4.getTime(),
+
+      glassbox: {
+        ...initialState.glassbox,
+        startTime: date2,
+        endTime: date3,
+        timeSpan: date3.getTime() - date2.getTime(),
+      },
     });
+  });
+
+  // 2 from SET_START_TIME
+  // 2 from SET_END_TIME
+  it("expect 9 console errors", () => {
+    expect(console.error).toHaveBeenCalledTimes(9);
   });
 
   // Glassbox
@@ -307,7 +365,9 @@ describe("Timeline reducer", () => {
       startTime: timelineStartTime,
       endTime: timelineEndTime,
       timeSpan: timelineExpectedTimeSpan,
+
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbStartTime,
         endTime: gbEndTime,
         timeSpan: gbExpectedTimeSpan,
@@ -320,8 +380,8 @@ describe("Timeline reducer", () => {
     // Action creator
     expect(gbSetTimeLimits(gbStartTime, gbEndTime)).toEqual({
       type: GB_SET_TIME_LIMITS,
-      start: gbStartTime,
-      end: gbEndTime,
+      gbStart: gbStartTime,
+      gbEnd: gbEndTime,
     });
 
     // Set startTime before endTime
@@ -330,13 +390,14 @@ describe("Timeline reducer", () => {
         { ...nextState },
         {
           type: GB_SET_TIME_LIMITS,
-          start: gbStartTime,
-          end: gbEndTime,
+          gbStart: gbStartTime,
+          gbEnd: gbEndTime,
         }
       )
     ).toEqual({
       ...nextState,
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbStartTime,
         endTime: gbEndTime,
         timeSpan: gbEndTime.getTime() - gbStartTime.getTime(),
@@ -348,12 +409,13 @@ describe("Timeline reducer", () => {
     expect(
       reducer(nextState, {
         type: GB_SET_TIME_LIMITS,
-        start: gbStartTime,
-        end: gbStartTime,
+        gbStart: gbStartTime,
+        gbEnd: gbStartTime,
       })
     ).toEqual({
       ...nextState,
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbStartTime,
         endTime: gbStartTime,
         timeSpan: gbStartTime.getTime() - gbStartTime.getTime(),
@@ -365,12 +427,13 @@ describe("Timeline reducer", () => {
     expect(
       reducer(nextState, {
         type: GB_SET_TIME_LIMITS,
-        start: gbEndTime,
-        end: gbStartTime,
+        gbStart: gbEndTime,
+        gbEnd: gbStartTime,
       })
     ).toEqual({
       ...nextState,
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbEndTime,
         endTime: gbStartTime,
         timeSpan: gbStartTime.getTime() - gbEndTime.getTime(),
@@ -382,12 +445,13 @@ describe("Timeline reducer", () => {
     expect(
       reducer(nextState, {
         type: GB_SET_TIME_LIMITS,
-        start: gbStartTimeBeforeTimeline,
-        end: gbEndTime,
+        gbStart: gbStartTimeBeforeTimeline,
+        gbEnd: gbEndTime,
       })
     ).toEqual({
       ...nextState,
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbStartTimeBeforeTimeline,
         endTime: gbEndTime,
         timeSpan: gbEndTime.getTime() - gbStartTimeBeforeTimeline.getTime(),
@@ -399,12 +463,13 @@ describe("Timeline reducer", () => {
     expect(
       reducer(nextState, {
         type: GB_SET_TIME_LIMITS,
-        start: gbStartTime,
-        end: gbEndTimeAfterTimeline,
+        gbStart: gbStartTime,
+        gbEnd: gbEndTimeAfterTimeline,
       })
     ).toEqual({
       ...nextState,
       glassbox: {
+        ...initialState.glassbox,
         startTime: gbStartTime,
         endTime: gbEndTimeAfterTimeline,
         timeSpan: gbEndTimeAfterTimeline.getTime() - gbStartTime.getTime(),
@@ -412,357 +477,10 @@ describe("Timeline reducer", () => {
     });
   });
 
-  it("expect 10 console errors", () => {
-    expect(console.error).toHaveBeenCalledTimes(10);
-  });
-});
-
-describe("Timeline component", () => {
-  // test getLinePlacements()
-  it("should handle getLinePlacements", () => {
-    // Setup variables
-    const startTime1 = new Date(2020, 3, 12, 12, 20, 13);
-    const endTime1 = new Date(2020, 3, 12, 17, 20, 13);
-    var timeSpan1 = endTime1.getTime() - startTime1.getTime();
-    var expReturn1 = [
-      "13.261111111111111%",
-      "33.26111111111111%",
-      "53.26111111111111%",
-      "73.2611111111111%",
-      "93.2611111111111%",
-    ];
-
-    const startTime2 = new Date(2020, 3, 11, 11, 10, 5);
-    const endTime2 = new Date(2020, 3, 12, 17, 20, 13);
-    var timeSpan2 = endTime2.getTime() - startTime2.getTime();
-    var expReturn2 = [
-      "2.757623747790218%",
-      "6.072296700058928%",
-      "9.386969652327636%",
-      "12.701642604596346%",
-      "16.016315556865056%",
-      "19.330988509133764%",
-      "22.645661461402476%",
-      "25.960334413671184%",
-      "29.275007365939892%",
-      "32.58968031820861%",
-      "35.904353270477316%",
-      "39.219026222746024%",
-      "42.53369917501473%",
-      "45.84837212728345%",
-      "49.163045079552155%",
-      "52.477718031820864%",
-      "55.79239098408957%",
-      "59.10706393635828%",
-      "62.421736888626995%",
-      "65.7364098408957%",
-      "69.05108279316441%",
-      "72.36575574543312%",
-      "75.68042869770183%",
-      "78.99510164997054%",
-      "82.30977460223924%",
-      "85.62444755450795%",
-      "88.93912050677667%",
-      "92.25379345904538%",
-      "95.56846641131409%",
-      "98.8831393635828%",
-    ];
-
-    const startTime3 = new Date(2020, 3, 10, 11, 10, 9);
-    const endTime3 = new Date(2020, 3, 19, 10, 20, 30);
-    var timeSpan3 = endTime3.getTime() - startTime3.getTime();
-    var expReturn3 = [
-      "0.3861243111147257%",
-      "0.8508677146630416%",
-      "1.3156111182113575%",
-      "1.7803545217596732%",
-      "2.2450979253079892%",
-      "2.7098413288563052%",
-      "3.174584732404621%",
-      "3.639328135952937%",
-      "4.104071539501252%",
-      "4.568814943049568%",
-      "5.033558346597884%",
-      "5.4983017501462%",
-      "5.963045153694516%",
-      "6.427788557242831%",
-      "6.892531960791147%",
-      "7.357275364339463%",
-      "7.822018767887779%",
-      "8.286762171436095%",
-      "8.751505574984412%",
-      "9.216248978532727%",
-      "9.680992382081044%",
-      "10.145735785629359%",
-      "10.610479189177674%",
-      "11.075222592725991%",
-      "11.539965996274306%",
-      "12.004709399822623%",
-      "12.469452803370938%",
-      "12.934196206919253%",
-      "13.39893961046757%",
-      "13.863683014015885%",
-      "14.328426417564202%",
-      "14.793169821112517%",
-      "15.257913224660832%",
-      "15.72265662820915%",
-      "16.187400031757463%",
-      "16.652143435305778%",
-      "17.116886838854096%",
-      "17.58163024240241%",
-      "18.046373645950727%",
-      "18.511117049499042%",
-      "18.975860453047357%",
-      "19.440603856595676%",
-      "19.90534726014399%",
-      "20.370090663692306%",
-      "20.83483406724062%",
-      "21.299577470788936%",
-      "21.764320874337255%",
-      "22.22906427788557%",
-      "22.693807681433885%",
-      "23.1585510849822%",
-      "23.623294488530515%",
-      "24.088037892078834%",
-      "24.55278129562715%",
-      "25.017524699175464%",
-      "25.48226810272378%",
-      "25.947011506272094%",
-      "26.411754909820413%",
-      "26.876498313368728%",
-      "27.341241716917043%",
-      "27.80598512046536%",
-      "28.270728524013673%",
-      "28.735471927561992%",
-      "29.200215331110307%",
-      "29.664958734658622%",
-      "30.129702138206937%",
-      "30.594445541755253%",
-      "31.05918894530357%",
-      "31.523932348851886%",
-      "31.988675752400205%",
-      "32.45341915594852%",
-      "32.918162559496835%",
-      "33.38290596304515%",
-      "33.847649366593465%",
-      "34.312392770141784%",
-      "34.777136173690096%",
-      "35.241879577238414%",
-      "35.706622980786726%",
-      "36.171366384335045%",
-      "36.63610978788336%",
-      "37.100853191431675%",
-      "37.56559659497999%",
-      "38.030339998528305%",
-      "38.495083402076624%",
-      "38.95982680562494%",
-      "39.424570209173254%",
-      "39.88931361272157%",
-      "40.354057016269884%",
-      "40.8188004198182%",
-      "41.28354382336652%",
-      "41.74828722691483%",
-      "42.21303063046315%",
-      "42.67777403401146%",
-      "43.14251743755978%",
-      "43.6072608411081%",
-      "44.07200424465641%",
-      "44.53674764820473%",
-      "45.00149105175304%",
-      "45.46623445530136%",
-      "45.93097785884968%",
-      "46.39572126239799%",
-      "46.86046466594631%",
-      "47.32520806949462%",
-      "47.78995147304294%",
-      "48.25469487659126%",
-      "48.71943828013957%",
-      "49.18418168368789%",
-      "49.6489250872362%",
-      "50.11366849078452%",
-      "50.57841189433284%",
-      "51.04315529788115%",
-      "51.50789870142947%",
-      "51.97264210497778%",
-      "52.4373855085261%",
-      "52.90212891207442%",
-      "53.36687231562273%",
-      "53.83161571917105%",
-      "54.29635912271936%",
-      "54.76110252626768%",
-      "55.225845929815996%",
-      "55.69058933336431%",
-      "56.15533273691263%",
-      "56.62007614046094%",
-      "57.08481954400926%",
-      "57.549562947557575%",
-      "58.01430635110589%",
-      "58.479049754654206%",
-      "58.94379315820252%",
-      "59.408536561750836%",
-      "59.873279965299155%",
-      "60.338023368847466%",
-      "60.802766772395785%",
-      "61.267510175944096%",
-      "61.732253579492415%",
-      "62.196996983040734%",
-      "62.661740386589045%",
-      "63.126483790137364%",
-      "63.591227193685675%",
-      "64.05597059723401%",
-      "64.52071400078232%",
-      "64.98545740433063%",
-      "65.45020080787894%",
-      "65.91494421142727%",
-      "66.37968761497558%",
-      "66.84443101852389%",
-      "67.30917442207222%",
-      "67.77391782562053%",
-      "68.23866122916884%",
-      "68.70340463271717%",
-      "69.16814803626548%",
-      "69.63289143981379%",
-      "70.0976348433621%",
-      "70.56237824691043%",
-      "71.02712165045874%",
-      "71.49186505400705%",
-      "71.95660845755538%",
-      "72.42135186110369%",
-      "72.886095264652%",
-      "73.35083866820032%",
-      "73.81558207174864%",
-      "74.28032547529695%",
-      "74.74506887884526%",
-      "75.20981228239359%",
-      "75.6745556859419%",
-      "76.13929908949021%",
-      "76.60404249303853%",
-      "77.06878589658685%",
-      "77.53352930013516%",
-      "77.99827270368348%",
-      "78.4630161072318%",
-      "78.9277595107801%",
-      "79.39250291432842%",
-      "79.85724631787674%",
-      "80.32198972142506%",
-      "80.78673312497337%",
-      "81.25147652852169%",
-      "81.71621993207%",
-      "82.18096333561832%",
-      "82.64570673916664%",
-      "83.11045014271495%",
-      "83.57519354626326%",
-      "84.03993694981158%",
-      "84.5046803533599%",
-      "84.96942375690821%",
-      "85.43416716045652%",
-      "85.89891056400485%",
-      "86.36365396755316%",
-      "86.82839737110147%",
-      "87.2931407746498%",
-      "87.75788417819811%",
-      "88.22262758174642%",
-      "88.68737098529473%",
-      "89.15211438884306%",
-      "89.61685779239137%",
-      "90.08160119593968%",
-      "90.54634459948801%",
-      "91.01108800303632%",
-      "91.47583140658463%",
-      "91.94057481013296%",
-      "92.40531821368127%",
-      "92.87006161722958%",
-      "93.33480502077789%",
-      "93.79954842432622%",
-      "94.26429182787453%",
-      "94.72903523142284%",
-      "95.19377863497117%",
-      "95.65852203851948%",
-      "96.12326544206779%",
-      "96.58800884561612%",
-      "97.05275224916443%",
-      "97.51749565271274%",
-      "97.98223905626105%",
-      "98.44698245980938%",
-      "98.91172586335769%",
-      "99.376469266906%",
-      "99.84121267045433%",
-    ];
-
-    const startTime4 = new Date(2020, 3, 10, 11, 10, 9);
-    var timeSpan4 = 0.001 * 60 * 60 * 1000;
-    var expReturn4 = [];
-
-    // get list of line placements #1
-    expect(getLinePlacements(startTime1, timeSpan1)).toEqual(expReturn1);
-
-    // get list of line placements #2
-    expect(getLinePlacements(startTime2, timeSpan2)).toEqual(expReturn2);
-
-    // get list of line placements #3
-    expect(getLinePlacements(startTime3, timeSpan3)).toEqual(expReturn3);
-
-    // get list of line placements #4
-    expect(getLinePlacements(startTime4, timeSpan4)).toEqual(expReturn4);
-  });
-
-  it("should handle getDayPlacements", () => {
-    // Setup variables for test 1
-    const startTime1 = new Date(2020, 3, 12, 12, 0, 0);
-    const endTime1 = new Date(2020, 3, 13, 12, 0, 0);
-    var timeSpan1 = endTime1.getTime() - startTime1.getTime();
-    var expReturn1 = [
-      ["50%", "0%", "Apr 12"],
-      ["50%", "50%", "Apr 13"],
-    ];
-
-    // Setup variables for test 2
-    const startTime2 = new Date(2020, 6, 25, 2, 0, 0);
-    const endTime2 = new Date(2020, 6, 25, 20, 0, 0);
-    var timeSpan2 = endTime2.getTime() - startTime2.getTime();
-    var expReturn2 = [["100%", "0%", "Jul 25"]];
-
-    // Setup variables for test 3
-    const startTime3 = new Date(2020, 11, 29, 12, 0, 0);
-    const endTime3 = new Date(2021, 0, 2, 12, 0, 0);
-    var timeSpan3 = endTime3.getTime() - startTime3.getTime();
-    var expReturn3 = [
-      ["12.5%", "0%", "Dec 29"],
-      ["25%", "12.5%", "Dec 30"],
-      ["25%", "37.5%", "Dec 31"],
-      ["25%", "62.5%", "Jan 1"],
-      ["12.5%", "87.5%", "Jan 2"],
-    ];
-
-    // Setup variables for test 4
-    const startTime4 = new Date(2001, 8, 11, 0, 0, 0);
-    const endTime4 = new Date(2001, 8, 21, 0, 0, 0);
-    var timeSpan4 = endTime4.getTime() - startTime4.getTime();
-    var expReturn4 = [
-      ["10%", "0%", "Sep 11"],
-      ["10%", "10%", "Sep 12"],
-      ["10%", "20%", "Sep 13"],
-      ["10%", "30%", "Sep 14"],
-      ["10%", "40%", "Sep 15"],
-      ["10%", "50%", "Sep 16"],
-      ["10%", "60%", "Sep 17"],
-      ["10%", "70%", "Sep 18"],
-      ["10%", "80%", "Sep 19"],
-      ["10%", "90%", "Sep 20"],
-    ];
-
-    // Execute tests
-    expect(getDayPlacements(startTime1, endTime1, timeSpan1)).toEqual(
-      expReturn1
-    );
-    expect(getDayPlacements(startTime2, endTime2, timeSpan2)).toEqual(
-      expReturn2
-    );
-    expect(getDayPlacements(startTime3, endTime3, timeSpan3)).toEqual(
-      expReturn3
-    );
-    expect(getDayPlacements(startTime4, endTime4, timeSpan4)).toEqual(
-      expReturn4
-    );
+  // 2 from SET_START_TIME
+  // 2 from SET_END_TIME
+  // 5 from SET_TIME_LIMITS
+  it("expect 13 console errors", () => {
+    expect(console.error).toHaveBeenCalledTimes(13);
   });
 });


### PR DESCRIPTION
This commit fixes alot of stuff!
timeline.js
 - timeline only renders divs visible on screen
 - timeline updates divs when scrolling
    (left pos, content, width, color, etc).
 - set scroll to glassbox-start-pos when switching mode

util.js
 - Set bounds for timeline (including glassbox)

stateTimeline.js
 - Updated action for set timeline limits, so it takes glassbox into
    consideration also.

timeline.test.js
 - Updated test for timeline

cliplines.js
 - fixed bug with cliplength width
 - cliplines now uses filtered clips

glassbox.js
 - pass reference from timeline to glassbox to be able to scroll
    glassbox into view when switching mode.

timeline.module.css
 - moved relevant css from timeline to css file
 - updated css for timeline

---------------------------------------------------------------------------------------------

Closes #333 
Closes #334 
Closes #301 
