### PR TITLE
fix: filter panel removed time zones

### DIFF
--- a/frontend/src/components/filter/filter.js
+++ b/frontend/src/components/filter/filter.js
@@ -177,8 +177,8 @@ class Filter extends Component {
             >
               <ListGroup.Item>
                 <strong>Time:</strong>
-                <p>{this.props.startTime.toString()}</p>-
-                <p>{this.props.endTime.toString()}</p>
+                <p>{this.props.startTime.toString().slice(0, 24)}</p>-
+                <p>{this.props.endTime.toString().slice(0, 24)}</p>
               </ListGroup.Item>
             </OverlayTrigger>{" "}
             <OverlayTrigger


### PR DESCRIPTION
Used "slice" instead of "toDateString()" so the time can be shown. 

Closes #364 